### PR TITLE
Resolve the issue of getting different results from transformers evaluation and vLLM evaluation

### DIFF
--- a/llmsql/evaluation/evaluator.py
+++ b/llmsql/evaluation/evaluator.py
@@ -185,6 +185,4 @@ class LLMSQLEvaluator:
                 json.dump(report, f, indent=2, ensure_ascii=False)
             log.info(f"Saved report to {save_report}")
 
-        self.close()
-
         return report


### PR DESCRIPTION
## Description
The different results were obtained depending on the evaluation method. To solve this issue, environment variables were added to `interference_vllm.py`.
```
os.environ["VLLM_USE_V1"] = "0"
os.environ["CUBLAS_WORKSPACE_CONFIG"]=":4096:8"
os.environ["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0"
```
After introducing the changes, all the tests were passed successfully.

